### PR TITLE
adds archival note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# This repository is superseded by the work at ToIP Technical Stack Working Group ACDC Task Force
+
+https://github.com/trustoverip/tswg-ipex-specification
+
+
 # TODO - Your title
 
 This is the working area for the individual Internet-Draft, "TODO - Your title".


### PR DESCRIPTION
Due to the proposed move to the Trust over IP Foundation, we should archive this repository.